### PR TITLE
Add MapValues and MapKeys functions as array_values and array_keys, O…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Test
       run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jesse-rb/imissphp-go
 
-go 1.19
+go 1.21

--- a/imissphp.go
+++ b/imissphp.go
@@ -34,42 +34,6 @@ func InArray[T comparable](val T, list []T) bool {
 	return false
 }
 
-// Normalize a reflect.Type by returning the element type if it is a pointer
-func normalizeReflectType(data reflect.Type) reflect.Type {
-	if data.Kind() == reflect.Pointer {
-		data = data.Elem()
-	}
-
-	return data
-}
-
-// Gets the name of the supplied value's type.
-// The i parameter can be either a value or a pointer to a value.
-// This function returns the string name of the supplied value's type.
-func TypeName(i interface{}) string {
-	data := reflect.TypeOf(i)
-
-	data = normalizeReflectType(data)
-
-	return data.Name()
-}
-
-// MethodExists checks if a method with the given name exists on a type.
-// The i parameter can be either a value or a pointer to a value.
-// The methodName can refer to a method with either a value receiver or a pointer receiver.
-// The function returns true if the method exists on either the value or its pointer type.
-func MethodExists(i interface{}, methodName string) bool {
-	data := reflect.TypeOf(i)
-
-	data = normalizeReflectType(data)
-
-	// Checks for MyStruct{}.MyMethod OR *MyStruct{}.MyMethod
-	_, hasMethod := data.MethodByName(methodName)
-	_, ptrHasMethod := reflect.PointerTo(data).MethodByName(methodName)
-
-	return hasMethod || ptrHasMethod
-}
-
 // Recursively converts a value of type `any` into a map[string]... structure.
 // Slices and arrays are converted to map[string]... as well with the index used as a string key.
 // Structs are converted using json.Marshal so that json struct tags are used.
@@ -214,4 +178,28 @@ func UnFlattenMap(node map[string]any) map[string]any {
 	}
 
 	return result
+}
+
+// Get values in map as slice
+// NOTE: Because maps are not ordered, the returned slice is unordered
+func MapValues[K comparable, V any](m map[K]V) []V {
+	s := make([]V, 0, len(m))
+
+	for _, value := range m {
+		s = append(s, value)
+	}
+
+	return s
+}
+
+// Get keys in map as slice
+// NOTE: Because maps are not ordered, the returned slice is unordered
+func MapKeys[K comparable, V any](m map[K]V) []K {
+	s := make([]K, 0, len(m))
+
+	for key := range m {
+		s = append(s, key)
+	}
+
+	return s
 }

--- a/imissphp_test.go
+++ b/imissphp_test.go
@@ -2,10 +2,9 @@ package imissphp
 
 import (
 	"encoding/json"
-	"log"
 	"reflect"
+	"slices"
 	"testing"
-	"time"
 )
 
 func TestUcFirst(t *testing.T) {
@@ -37,50 +36,6 @@ func TestInArray(t *testing.T) {
 
 	if InArray(0, testIntArray) == true {
 		t.Fatalf("Did not expect 0 to be in the array")
-	}
-}
-
-func TestTypeName(t *testing.T) {
-	expectedA := "Logger"
-	testA := &log.Logger{}
-	actualA := TypeName(testA)
-
-	if actualA != expectedA {
-		t.Fatalf("Expected struct %s to have name %s", actualA, expectedA)
-	}
-
-	expectedB := "Time"
-	testB := time.Time{}
-	actualB := TypeName(testB)
-
-	if actualB != expectedB {
-		t.Fatalf("Expected struct %s to have name %s", actualB, expectedB)
-	}
-}
-
-func TestMethodExists(t *testing.T) {
-	testStructA := log.Logger{}
-	testMethodA1 := "Fatal"
-	testMethodA2 := "DebugzzzzNotReal"
-
-	if MethodExists(&testStructA, testMethodA1) == false {
-		t.Fatalf("Expected method %s to exist on struct %s", testMethodA1, TypeName(&testStructA))
-	}
-
-	if MethodExists(&testStructA, testMethodA2) == true {
-		t.Fatalf("Did not expect method %s to exist on struct %s", testMethodA2, TypeName(&testStructA))
-	}
-
-	testStructB := &time.Time{}
-	testMethodB1 := "Date"
-	testMethodB2 := "NZTimezzzzDefinitelyReal"
-
-	if MethodExists(testStructB, testMethodB1) == false {
-		t.Fatalf("Expected method %s to exist on struct %s", testMethodB1, TypeName(testStructB))
-	}
-
-	if MethodExists(testStructB, testMethodB2) == true {
-		t.Fatalf("Did not expect method %s to exist on struct %s", testMethodB2, TypeName(testStructB))
 	}
 }
 
@@ -344,5 +299,71 @@ func TestUnFlattenMap(t *testing.T) {
 				t.Errorf("UnFlattenMap() = %v, expected %v", got, tc.expected)
 			}
 		})
+	}
+}
+
+func TestMapValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]int
+		expected []int
+	}{
+		{
+			input: map[string]int{
+				"one": 1, "awljdnjwnd": 983, "-3": -33,
+			},
+			expected: []int{
+				1, 983, -33,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := MapValues(test.input)
+		if len(actual) != len(test.expected) {
+			t.Fatalf("Expected actual length: %v to match expected length: %v", len(actual), len(test.expected))
+		}
+
+		slices.Sort(actual)
+		slices.Sort(test.expected)
+
+		for i := 0; i < len(actual); i++ {
+			if actual[i] != test.expected[i] {
+				t.Fatalf("Expected actual[%v]: %v to equal expected[%v]: %v", i, actual[i], i, test.expected[i])
+			}
+		}
+	}
+}
+
+func TestMapKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]int
+		expected []string
+	}{
+		{
+			input: map[string]int{
+				"abc": 1, "BC-2": 32, "23": 9982,
+			},
+			expected: []string{
+				"abc", "BC-2", "23",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := MapKeys(test.input)
+		if len(actual) != len(test.expected) {
+			t.Fatalf("Expected actual length: %v to match expected length: %v", len(actual), len(test.expected))
+		}
+
+		slices.Sort(actual)
+		slices.Sort(test.expected)
+
+		for i := 0; i < len(actual); i++ {
+			if actual[i] != test.expected[i] {
+				t.Fatalf("Expected actual[%v]: %v to equal expected[%v]: %v", i, actual[i], i, test.expected[i])
+			}
+		}
 	}
 }


### PR DESCRIPTION
- Removed 3 functions that doesn't seem like it would be particularly useful for go `normalizeReflectType()`, `TypeName()`, and `MethodExists()`
- Add `MapValues()` and `MapKeys()` functions as equivalent to php `array_values()` and `array_keys()` functions, or js `Object.values()` and `Object.keys()` functions
- Added tests
- Update module version to go 1.21 to make use of convenient `slices.Sort()` function